### PR TITLE
support thumb creation for JPG,JPEG,PNG,GIF uppercase file extention

### DIFF
--- a/src/Jasekz/Laradrop/Http/Controllers/LaradropController.php
+++ b/src/Jasekz/Laradrop/Http/Controllers/LaradropController.php
@@ -125,7 +125,7 @@ class LaradropController extends BaseController {
              * create thumbnail if needed
              */
             $fileData['has_thumbnail'] = 0;
-            if ($fileSize <= ( (int) config('laradrop.max_thumbnail_size') * 1000000) && in_array($fileExt, ['jpg', 'jpeg', 'png', 'gif'])) {
+            if ($fileSize <= ( (int) config('laradrop.max_thumbnail_size') * 1000000) && in_array($fileExt, ['jpg','JPG', 'jpeg','JPEG', 'png', 'PNG',  'gif', 'GIF'])) {
 
                 $thumbDims = config('laradrop.thumb_dimensions');
                 $img = Image::make($tmpStorage . '/' . $movedFileName);

--- a/src/Jasekz/Laradrop/Http/Controllers/LaradropController.php
+++ b/src/Jasekz/Laradrop/Http/Controllers/LaradropController.php
@@ -125,7 +125,7 @@ class LaradropController extends BaseController {
              * create thumbnail if needed
              */
             $fileData['has_thumbnail'] = 0;
-            if ($fileSize <= ( (int) config('laradrop.max_thumbnail_size') * 1000000) && in_array($fileExt, ['jpg','JPG', 'jpeg','JPEG', 'png', 'PNG',  'gif', 'GIF'])) {
+            if ($fileSize <= ( (int) config('laradrop.max_thumbnail_size') * 1000000) && in_array(strtolower($fileExt), ['jpg','JPG', 'jpeg','JPEG', 'png', 'PNG',  'gif', 'GIF'])) {
 
                 $thumbDims = config('laradrop.thumb_dimensions');
                 $img = Image::make($tmpStorage . '/' . $movedFileName);

--- a/src/Jasekz/Laradrop/Http/Controllers/LaradropController.php
+++ b/src/Jasekz/Laradrop/Http/Controllers/LaradropController.php
@@ -125,7 +125,7 @@ class LaradropController extends BaseController {
              * create thumbnail if needed
              */
             $fileData['has_thumbnail'] = 0;
-            if ($fileSize <= ( (int) config('laradrop.max_thumbnail_size') * 1000000) && in_array(strtolower($fileExt), ['jpg','JPG', 'jpeg','JPEG', 'png', 'PNG',  'gif', 'GIF'])) {
+            if ($fileSize <= ( (int) config('laradrop.max_thumbnail_size') * 1000000) && in_array(strtolower($fileExt), ['jpg', 'jpeg', 'png', 'gif'])) {
 
                 $thumbDims = config('laradrop.thumb_dimensions');
                 $img = Image::make($tmpStorage . '/' . $movedFileName);


### PR DESCRIPTION
support thumb creation for JPG,JPEG,PNG,GIF uppercase file extention. Currently, if the file extension is uppercase, the thumbnail will not be created due to check for supported extension failure.
Please merge this improvement
