### PR TITLE
When store new file, if we have thumbnail, we change filename to thum…

### DIFF
--- a/src/Jasekz/Laradrop/Http/Controllers/LaradropController.php
+++ b/src/Jasekz/Laradrop/Http/Controllers/LaradropController.php
@@ -167,7 +167,14 @@ class LaradropController extends BaseController {
                 'file'     => $file,
                 'postData' => Input::all()
             ]));
-            
+            /* if we have thumbnail, we change filename to thumbnail for client side update */
+            if( $file->has_thumbnail ) {
+                $publicResourceUrlSegments = explode('/', $file->public_resource_url);
+                $publicResourceUrlSegments[count($publicResourceUrlSegments) - 1] = '_thumb_' . $publicResourceUrlSegments[count($publicResourceUrlSegments) - 1];
+                $file->filename = implode('/', $publicResourceUrlSegments);
+            } else {
+                $file->filename = config('laradrop.default_thumbnail_url');
+            }
             return $file;
             
         } 


### PR DESCRIPTION
…bnail for client side use

if we have thumbnail, we change filename to thumbnail for client side to display. This is the same behavior as index action in this controller
Please consider whether or not merge this.
I use vuejs as the front end data-driven app dev. When uploaded file, if this $file with thumb returned, client side will update view automatically with this returned data. Otherwise, no thumb image can be retrieved
